### PR TITLE
Add name as argument for creating a job

### DIFF
--- a/runjob.go
+++ b/runjob.go
@@ -16,41 +16,43 @@ import (
 	"gopkg.in/robfig/cron.v2"
 )
 
-// Callers can use jobs.Func to wrap a raw func.
-// (Copying the type to this package makes it more visible)
+// Func is used to wrap a function literal as a job.
 //
 // For example:
 //    jobrunner.Schedule("cron.frequent", jobs.Func(myFunc))
 type Func func()
 
+// Run will execute the underlying job logic
 func (r Func) Run() { r() }
 
-func Schedule(spec string, job cron.Job) error {
+// Schedule will enqueue a job with the supplied name to execute according to
+// the specification (spec) supplied.
+func Schedule(name string, spec string, job cron.Job) error {
 	sched, err := cron.Parse(spec)
 	if err != nil {
 		return err
 	}
-	MainCron.Schedule(sched, New(job))
+	MainCron.Schedule(sched, New(name, job))
 	return nil
 }
 
-// Run the given job at a fixed interval.
-// The interval provided is the time between the job ending and the job being run again.
+// Every will run the given job at a fixed interval. The interval provided is
+// the time between the job ending and the job being run again.
 // The time that the job takes to run is not included in the interval.
-func Every(duration time.Duration, job cron.Job) {
+func Every(duration time.Duration, name string, job cron.Job) {
 
-	MainCron.Schedule(cron.Every(duration), New(job))
+	MainCron.Schedule(cron.Every(duration), New(name, job))
 }
 
-// Run the given job right now.
-func Now(job cron.Job) {
-	go New(job).Run()
+// Now will run the given job immediately.
+func Now(name string, job cron.Job) {
+	go New(name, job).Run()
 }
 
-// Run the given job once, after the given delay.
-func In(duration time.Duration, job cron.Job) {
+// In will run the given job once, after the given delay.
+func In(duration time.Duration, name string, job cron.Job) {
 	go func() {
 		time.Sleep(duration)
-		New(job).Run()
+		New(name, job).Run()
 	}()
 }

--- a/status.go
+++ b/status.go
@@ -6,26 +6,29 @@ import (
 	"gopkg.in/robfig/cron.v2"
 )
 
+// StatusData encapsulates the relevant data regarding a single Job.
 type StatusData struct {
-	Id        cron.EntryID
+	ID        cron.EntryID
 	JobRunner *Job
 	Next      time.Time
 	Prev      time.Time
 }
 
-// Return detailed list of currently running recurring jobs
+// Entries will return a detailed list of currently running recurring jobs
 // to remove an entry, first retrieve the ID of entry
 func Entries() []cron.Entry {
 	return MainCron.Entries()
 }
 
+// StatusPage returns a slice of StatusData suitable for constructing a status
+// page.
 func StatusPage() []StatusData {
 
 	ents := MainCron.Entries()
 
 	Statuses := make([]StatusData, len(ents))
 	for k, v := range ents {
-		Statuses[k].Id = v.ID
+		Statuses[k].ID = v.ID
 		Statuses[k].JobRunner = AddJob(v.Job)
 		Statuses[k].Next = v.Next
 		Statuses[k].Prev = v.Prev
@@ -41,7 +44,9 @@ func StatusPage() []StatusData {
 	return Statuses
 }
 
-func StatusJson() map[string]interface{} {
+// StatusJSON returns a map with the slice of StatusData assigned to the
+// key 'jobrunner'.
+func StatusJSON() map[string]interface{} {
 
 	return map[string]interface{}{
 		"jobrunner": StatusPage(),
@@ -49,6 +54,7 @@ func StatusJson() map[string]interface{} {
 
 }
 
+// AddJob will cast a cron.Job to become a jobrunner.Job.
 func AddJob(job cron.Job) *Job {
 	return job.(*Job)
 }


### PR DESCRIPTION
Having an explicit name for a job is helpful to disambiguate multiple
jobs that may be started using the same structure or for having a
more intuitive name for jobs defined with function literals.